### PR TITLE
Upgrade to node 18 and npm 9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build on top of base node image
-FROM node:16.16.0
+FROM node:18.16.0
 
 # install libraries required by IPG Lock
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
@@ -8,14 +8,14 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
 # download and compile python
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     build-essential
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    libreadline-gplv2-dev libncursesw5-dev libssl-dev \
-    libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev libffi-dev zlib1g-dev
+
+RUN apt install build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev libsqlite3-dev wget libbz2-dev -y
 WORKDIR /opt
 RUN wget https://www.python.org/ftp/python/3.8.0/Python-3.8.0.tgz
 RUN tar xzf Python-3.8.0.tgz
 WORKDIR /opt/Python-3.8.0
 RUN ./configure --enable-optimizations
+RUN make -j 8
 RUN make altinstall
 
 # install pip
@@ -23,4 +23,4 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN python3.8 get-pip.py
 
 # install latest npm
-RUN npm install -g npm@8.16.0
+RUN npm install -g npm@9.1.2

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Dockerfile for a Linux image that has NodeJS and Python installed. This is a base container for our web applications that require NodeJS and Python.
 
-- NodeJS 16.13.0
+- NodeJS 18.16.0
 - Python 3.8.0
 
 ## Build & push image to DockerHub
@@ -22,5 +22,5 @@ Now you can create the builds.
 ```
 docker buildx use ipgbuilder
 docker buildx inspect --bootstrap
-docker buildx build --platform linux/amd64,linux/arm64 --tag ipgautomotive/nodejs-python:latest --push .
+docker buildx build --platform linux/amd64,linux/arm64 --tag ipgautomotive/nodejs-python:node18 --push .
 ```


### PR DESCRIPTION
## Changes

Updated the Node-JS Python Docker container from Node 16 and NPM 8 to Node 18 and NPM 9 to align with all other VIRTO apps which are now running Node 18. I've gone with a new unique tag name rather than latest so we can adopt when ready in VIRTO.

## Testing notes

We tested the build and push on my machine earlier during VIRTO.DATA debug session and we tested VIRTO.DATA and VIRTO.TEST RUNNER still function as before with the updates. These are the only two VIRTO services still using this image. No further testing required.

## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] Branch has been run in docker.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
